### PR TITLE
fix(ci): version-faithful replacement of fake action SHA pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,13 +255,13 @@ jobs:
           deno bundle src/Main.mjs dist/laniakea.bundle.js || true
 
       - name: Upload server artifact
-        uses: actions/upload-artifact@ea165f8d65b6db9a8b71b5c2d1a090c0daf9c8bb # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: server-release
           path: server/_build/prod/rel/laniakea
 
       - name: Upload client artifact
-        uses: actions/upload-artifact@ea165f8d65b6db9a8b71b5c2d1a090c0daf9c8bb # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: client-bundle
           path: client/dist/


### PR DESCRIPTION
## Summary

Replaces fake action SHA pins with version-faithful real SHAs. Each fake here is a partial-prefix corruption of a real version's SHA — the author intended a specific version (per the `# vX.Y.Z` comment) but the suffix was fabricated.

The fix restores author intent rather than blindly bumping. This matters for actions where check-name reporting can differ between major versions (CodeQL especially) — preserving the major version preserves any branch-protection contexts referencing check names.

## Replacement table

Only substitutions where the fake SHA was actually present in this repo's workflows were applied; the diff shows exactly what changed.

| Action | Version intent | Real SHA |
|---|---|---|
| `goto-bus-stop/setup-zig` | v2.2.1 | `abea47f85e598557f500fa1fd2ab7464fcb39406` |
| `erlef/setup-beam` | v1.24.0 / v1.19.0 / v1.18.2 | per-pin (see diff) |
| `denoland/setup-deno` | v2.0.4 / v2.0.2 / v1.1.4 | per-pin |
| `haskell-actions/setup` | v2.11.0 | `cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553` |
| `actions/upload-artifact` | v4.6.2 | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `actions/setup-node` | v4.4.0 / v4.2.0 | per-pin |
| `trufflesecurity/trufflehog` | v3.95.3 / v3.82.13 / v3.63.6 | per-pin |
| `github/codeql-action/*` | v3.36.0 / v3.31.10 / v3.28.0 / v4.36.0 | per-pin (major preserved) |
| `Swatinem/rust-cache` | v2.7.8 | `9d47c6ad4b02e050fd481d890b2ea34778fd09d6` |
| `gitleaks/gitleaks-action` | v2.3.7 | `83373cf2f8c4db6e24b41c1a9b086bb9619e9cd3` |

All real SHAs verified via `gh api repos/<org>/<action>/commits/<sha>`.

## Provenance

Estate audit 2026-05-30 found 67 fake action SHA pins across ~50 repos via gh-api 422 verification of 372 unique pins. Round-1 (16 repos) swept the 4 widespread template-comment fakes; this PR is part of round-2 covering the long-tail single/few-repo fakes.

Full audit data at `~/Documents/estate-fake-shas-2026-05-30.tsv`.

## Test plan

- [ ] Diff shows only fake-SHA → real-SHA substitutions in `.github/workflows/*.yml`
- [ ] No major version changes (same X in `vX.Y.Z`); check-name reporting unchanged
- [ ] Action steps that previously 422'd now resolve correctly