### PR TITLE
chore(licence): normalise to MPL-2.0 + CC-BY-SA-4.0 (canonical pair)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 ## Machine-Readable Artefacts

--- a/.machine_readable/6a2/README.adoc
+++ b/.machine_readable/6a2/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 # A2ML 6a2 Directory
 

--- a/.machine_readable/6a2/anchor/README.adoc
+++ b/.machine_readable/6a2/anchor/README.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 # A2ML Anchor Directory
 

--- a/.machine_readable/contractiles/Justfile
+++ b/.machine_readable/contractiles/Justfile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT OR Apache-2.0
+# SPDX-License-Identifier: MPL-2.0 OR Apache-2.0
 # Laniakea - Comprehensive Build System
 # Run `just --list` for available recipes
 # Run `just --help <recipe>` for recipe details

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Changelog

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Contributor Covenant Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Contributing to Laniakea

--- a/GOVERNANCE.adoc
+++ b/GOVERNANCE.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 = Governance Model
 :toc: preamble

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-SPDX-License-Identifier: MPL-2.0
-SPDX-FileCopyrightText: 2024-2026 Jonathan D.A. Jewell (hyperpolymath)
-
 Mozilla Public License Version 2.0
 ==================================
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Maintainers

--- a/PROOF-NEEDS.md
+++ b/PROOF-NEEDS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # PROOF-NEEDS.md — laniakea

--- a/README.adoc.invariants.md
+++ b/README.adoc.invariants.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Invariant Path Scan: README.adoc

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Security Policy

--- a/TEST-NEEDS.md
+++ b/TEST-NEEDS.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # TEST-NEEDS.md — laniakea

--- a/claude.md
+++ b/claude.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Laniakea - AI Context Document

--- a/docs/CITATIONS.adoc
+++ b/docs/CITATIONS.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 = laniakea - Citation Guide
 :toc:

--- a/docs/comparisons/elm-nextjs-react.md
+++ b/docs/comparisons/elm-nextjs-react.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Elm vs Next.js vs React: Comprehensive Comparison

--- a/docs/justfile-cookbook.adoc
+++ b/docs/justfile-cookbook.adoc
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MPL-2.0
+// SPDX-License-Identifier: CC-BY-SA-4.0
 // Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 = Laniakea Justfile Cookbook
 :toc: macro

--- a/docs/whitepapers/academic.md
+++ b/docs/whitepapers/academic.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Laniakea: A CRDT-Based Architecture for Browser-as-Peer Distributed Web Applications

--- a/docs/whitepapers/industry.md
+++ b/docs/whitepapers/industry.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Laniakea: Distributed State Architecture for Modern Web Applications

--- a/docs/whitepapers/industry.md.invariants.md
+++ b/docs/whitepapers/industry.md.invariants.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Invariant Path Scan: industry.md

--- a/docs/whitepapers/public.md
+++ b/docs/whitepapers/public.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Laniakea: Making Web Apps Work Everywhere

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Laniakea Architecture

--- a/docs/wiki/CRDTs.md
+++ b/docs/wiki/CRDTs.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # CRDTs: Conflict-free Replicated Data Types

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # Laniakea Wiki

--- a/llm-warmup-dev.md
+++ b/llm-warmup-dev.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # LLM Warmup — laniakea (Developer)

--- a/llm-warmup-user.md
+++ b/llm-warmup-user.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: CC-BY-SA-4.0
 Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
 -->
 # LLM Warmup — laniakea (User)


### PR DESCRIPTION
Estate licence normalisation. LICENSES/={MPL-2.0,CC-BY-SA-4.0}; root LICENSE=verbatim MPL-2.0 (GitHub display); code->MPL-2.0, docs(.md/.adoc)->CC-BY-SA-4.0; vendored untouched. Residual mentions (mostly legitimate anti-AGPL rules): 13. Manual-review licence PR.